### PR TITLE
Issue #37 - Ensure consist sort order for versions

### DIFF
--- a/src/bin/svm
+++ b/src/bin/svm
@@ -100,9 +100,8 @@ _svm_get_latest_version_available_to_install() {
     local sorted=()
 
     install_versions=($(_svm_get_versions_available_to_install))
-    sorted=($(for version in ${install_versions[@]}; do echo $version; done | sort))
-
-    echo $(_svm_parse_version_from_versionsavailabletoinstall_record ${sorted[${#sorted[@]} - 1]})
+    latest=$(for version in ${install_versions[@]}; do echo $(_svm_parse_version_from_versionsavailabletoinstall_record "$version"); done | sort -V -r | head -1)
+    echo $latest
 }
 
 _svm_download_scriptcs_nugetpackage() {
@@ -235,16 +234,16 @@ _svm_help() {
 
 _svm_install_list() {
   local install_versions=()
+  local sorted_versions=()
 
   install_versions=($(_svm_get_versions_available_to_install))
-  if [ ${#install_versions[@]} -gt 0 ]; then
+  sorted_versions=($(for version in ${install_versions[@]}; do echo $(_svm_parse_version_from_versionsavailabletoinstall_record "$version"); done | sort -V -r))
+  if [ ${#sorted_versions[@]} -gt 0 ]; then
     local format_string="  %s\n"
-    local record_version=""
 
     _svm_info_message "The following scriptcs versions are available for installation:\n"
-    for install_version in "${install_versions[@]}"; do
-      record_version=$(_svm_parse_version_from_versionsavailabletoinstall_record "$install_version")
-      printf "$format_string" "$record_version"
+    for install_version in "${sorted_versions[@]}"; do
+      printf "$format_string" "$install_version"
     done
   else
     _svm_info_message "No scriptcs versions could be found to install."

--- a/src/bin/svm.ps1
+++ b/src/bin/svm.ps1
@@ -132,7 +132,7 @@ function Get-LatestVersionAvailableToInstall
 {
     $sorted = @()
 
-    $sorted = Get-VersionsAvailableToInstall | Sort-Object -Property Version -Descending
+    $sorted = Get-VersionsAvailableToInstall | Sort-Object -Property PublishedDate -Descending
 
     return $sorted[0].Version
 }


### PR DESCRIPTION
The `svm install -l` command on *nix sorts the versions in a reverse order to on Windows. Going forward all versions will be sorted from newest to oldest. This must be applied to ALL functionality using sorting of versions.

Care must be taken with version numbers since default sorting can lead to incorrect version order.

On Windows, the `PublishDate` of the version release will be used. On *nix, `sort -V -r` will be used as this understands version numbers and sorts them correctly.