### PR TITLE
Updated regex for finding junction targets

### DIFF
--- a/src/bin/svm-script.ps1
+++ b/src/bin/svm-script.ps1
@@ -256,7 +256,7 @@ function Get-JunctionTarget
 
   $item = Get-Item "$sourcePath"
   $command = 'cmd /c dir /A:L "' + $item.Parent.FullName + '"'
-  Invoke-Expression "$command" |? { $_ -match "${$item.BaseName}\[(.+)\]"} | Out-Null
+  Invoke-Expression "$command" |? { $_ -match "$($item.BaseName) \[(.+)\]"} | Out-Null
   return $matches[1]
 }
 


### PR DESCRIPTION
The previous regex pattern matched all lines from the dir command
causing all installs from the file system to display the directory
of the first one in the list.

The changes were to use $() instead of ${} for the string interpolation
and to add a space between the item base name and the [] containing
the target directory.

I tested it with my installs referenced in #77 and it is working locally.

Fixes #77